### PR TITLE
Override live server root directory on vscode

### DIFF
--- a/arkanoid-ts-startHere/.vscode/settings.json
+++ b/arkanoid-ts-startHere/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "liveServer.settings.root": "/dist"
 }


### PR DESCRIPTION
Override Live Server (by Riwick Dey) root directory on vscode to not server files from workspace but dist directory